### PR TITLE
mention that .gcn extension is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For files with the extensions
 - .isa.txt
 - .il
 - .il.txt
+- .gcn
 
 the following tokens are emitted:
 - `comment.block.amd-gcn-isa`


### PR DESCRIPTION
mention that .gcn extension is supported. See here, https://github.com/Melirius/AMD-GCN-ISA-for-CLRX/blob/1b99f48b915a15d0e79ffabbba36853965e081e9/package.json#L27